### PR TITLE
Fixed issue 8: fixed button disable interactions.

### DIFF
--- a/src/main/java/ui/MoveMethodPanel.java
+++ b/src/main/java/ui/MoveMethodPanel.java
@@ -134,16 +134,23 @@ class MoveMethodPanel extends JPanel {
         doRefactorButton.setEnabled(model.isAnySelected());
         selectAllButton.setEnabled(model.getRowCount() != 0);
         deselectAllButton.setEnabled(model.isAnySelected());
+        refreshButton.setEnabled(true);
     }
 
     private void disableButtonsButRefresh() {
         doRefactorButton.setEnabled(false);
         selectAllButton.setEnabled(false);
         deselectAllButton.setEnabled(false);
+        refreshButton.setEnabled(false);
+    }
+
+    private void disableAllButtons() {
+        disableButtonsButRefresh();
+        refreshButton.setEnabled(false);
     }
 
     private void refactorSelected() {
-        disableButtonsButRefresh();
+        disableAllButtons();
         table.setEnabled(false);
 
         final Set<MoveMethodRefactoring> selectedRefactorings = new HashSet<>(model.pullSelected());
@@ -156,17 +163,13 @@ class MoveMethodPanel extends JPanel {
     }
 
     private void refreshPanel() {
-        model.removeTableModelListener(tableRefreshListener);
-        disableButtonsButRefresh();
+        disableAllButtons();
 
         refactorings.clear();
         model.clearTable();
         infoLabel.setText(IntelliJDeodorantBundle.message(TOTAL_LABEL_TEXT_KEY) + model.getRowCount());
         scrollPane.setVisible(false);
         calculateRefactorings();
-
-        enableButtonsOnConditions();
-        model.addTableModelListener(tableRefreshListener);
     }
 
     private void calculateRefactorings() {
@@ -187,6 +190,8 @@ class MoveMethodPanel extends JPanel {
                     model.updateTable(refactorings);
                     scrollPane.setVisible(true);
                     infoLabel.setText(IntelliJDeodorantBundle.message(TOTAL_LABEL_TEXT_KEY) + model.getRowCount());
+
+                    enableButtonsOnConditions();
                 });
             }
         };

--- a/src/main/java/ui/MoveMethodPanel.java
+++ b/src/main/java/ui/MoveMethodPanel.java
@@ -101,20 +101,19 @@ class MoveMethodPanel extends JPanel {
         infoLabel.setPreferredSize(new Dimension(80, 30));
         buttonsPanel.add(infoLabel);
 
-        doRefactorButton.setEnabled(false);
-        selectAllButton.setEnabled(false);
-        deselectAllButton.setEnabled(false);
-
         selectAllButton.setText(IntelliJDeodorantBundle.message(SELECT_ALL_BUTTON_TEXT_KEY));
         selectAllButton.addActionListener(e -> model.selectAll());
+        selectAllButton.setEnabled(false);
         buttonsPanel.add(selectAllButton);
 
         deselectAllButton.setText(IntelliJDeodorantBundle.message(DESELECT_ALL_BUTTON_TEXT_KEY));
         deselectAllButton.addActionListener(e -> model.deselectAll());
+        deselectAllButton.setEnabled(false);
         buttonsPanel.add(deselectAllButton);
 
         doRefactorButton.setText(IntelliJDeodorantBundle.message(REFACTOR_BUTTON_TEXT_KEY));
         doRefactorButton.addActionListener(e -> refactorSelected());
+        doRefactorButton.setEnabled(false);
         buttonsPanel.add(doRefactorButton);
 
         refreshButton.setText(IntelliJDeodorantBundle.message(REFRESH_BUTTON_TEXT_KEY));
@@ -134,6 +133,7 @@ class MoveMethodPanel extends JPanel {
         deselectAllButton.setEnabled(model.isAnySelected());
         refreshButton.setEnabled(true);
     }
+
     private void disableAllButtons() {
         doRefactorButton.setEnabled(false);
         selectAllButton.setEnabled(false);

--- a/src/main/java/ui/MoveMethodPanel.java
+++ b/src/main/java/ui/MoveMethodPanel.java
@@ -25,7 +25,6 @@ import utils.IntelliJDeodorantBundle;
 import utils.PsiUtils;
 
 import javax.swing.*;
-import javax.swing.event.TableModelListener;
 import javax.swing.table.TableColumn;
 import java.awt.*;
 import java.awt.event.MouseEvent;
@@ -61,7 +60,6 @@ class MoveMethodPanel extends JPanel {
     private final JButton refreshButton = new JButton();
     private final List<MoveMethodRefactoring> refactorings = new ArrayList<>();
     private JScrollPane scrollPane = new JScrollPane();
-    private TableModelListener tableRefreshListener;
 
     MoveMethodPanel(@NotNull AnalysisScope scope) {
         this.scope = scope;
@@ -103,7 +101,9 @@ class MoveMethodPanel extends JPanel {
         infoLabel.setPreferredSize(new Dimension(80, 30));
         buttonsPanel.add(infoLabel);
 
-        disableButtonsButRefresh();
+        doRefactorButton.setEnabled(false);
+        selectAllButton.setEnabled(false);
+        deselectAllButton.setEnabled(false);
 
         selectAllButton.setText(IntelliJDeodorantBundle.message(SELECT_ALL_BUTTON_TEXT_KEY));
         selectAllButton.addActionListener(e -> model.selectAll());
@@ -119,12 +119,10 @@ class MoveMethodPanel extends JPanel {
 
         refreshButton.setText(IntelliJDeodorantBundle.message(REFRESH_BUTTON_TEXT_KEY));
         refreshButton.addActionListener(l -> refreshPanel());
-        refreshButton.setEnabled(true);
         buttonsPanel.add(refreshButton);
         panel.add(buttonsPanel, BorderLayout.EAST);
 
-        tableRefreshListener = l -> enableButtonsOnConditions();
-        model.addTableModelListener(tableRefreshListener);
+        model.addTableModelListener(l -> enableButtonsOnConditions());
 
         panel.add(info, BorderLayout.WEST);
         return panel;
@@ -136,16 +134,10 @@ class MoveMethodPanel extends JPanel {
         deselectAllButton.setEnabled(model.isAnySelected());
         refreshButton.setEnabled(true);
     }
-
-    private void disableButtonsButRefresh() {
+    private void disableAllButtons() {
         doRefactorButton.setEnabled(false);
         selectAllButton.setEnabled(false);
         deselectAllButton.setEnabled(false);
-        refreshButton.setEnabled(false);
-    }
-
-    private void disableAllButtons() {
-        disableButtonsButRefresh();
         refreshButton.setEnabled(false);
     }
 
@@ -164,7 +156,6 @@ class MoveMethodPanel extends JPanel {
 
     private void refreshPanel() {
         disableAllButtons();
-
         refactorings.clear();
         model.clearTable();
         infoLabel.setText(IntelliJDeodorantBundle.message(TOTAL_LABEL_TEXT_KEY) + model.getRowCount());

--- a/src/main/java/ui/MoveMethodTableModel.java
+++ b/src/main/java/ui/MoveMethodTableModel.java
@@ -52,6 +52,8 @@ public class MoveMethodTableModel extends AbstractTableModel {
     void clearTable() {
         this.refactorings.clear();
         this.virtualRows.clear();
+        isSelected = new boolean[0];
+        isActive = new boolean[0];
         fireTableDataChanged();
     }
 


### PR DESCRIPTION
1). Only Refresh button should be active on startup.
2). Select all button should be active only if there are results in table.
3). Deselect all button should be active only if one or more suggestions are selected.
4). Deselect all and Select all buttons should be disabled while table is refreshing.
5). Refactor button should be active only if one or more suggestions are selected.