### PR TITLE
Bug fixes in pre-processing 

### DIFF
--- a/src/main/java/org/jetbrains/research/intellijdeodorant/core/ast/AbstractMethodInvocationObject.java
+++ b/src/main/java/org/jetbrains/research/intellijdeodorant/core/ast/AbstractMethodInvocationObject.java
@@ -30,6 +30,7 @@ public abstract class AbstractMethodInvocationObject {
         this.methodName = methodName;
         this.returnType = returnType;
         this.parameterList = parameterList;
+        this.thrownExceptions = new LinkedHashSet<>();
         this._static = false;
     }
 

--- a/src/main/java/org/jetbrains/research/intellijdeodorant/core/ast/MethodObject.java
+++ b/src/main/java/org/jetbrains/research/intellijdeodorant/core/ast/MethodObject.java
@@ -221,10 +221,18 @@ public class MethodObject implements AbstractMethodDeclaration {
                     }
                 }
                 if (methodInvocation != null) {
-                    PsiReferenceExpression methodInvocationExpression = methodInvocation.getMethodExpression();
+                    PsiExpression methodInvocationExpression = methodInvocation.getMethodExpression().getQualifierExpression();
                     List<MethodInvocationObject> methodInvocations = statementObject.getMethodInvocations();
-                    if (methodInvocationExpression.resolve() instanceof PsiMethod) {
-                        PsiMethod previousChainedMethodInvocation = (PsiMethod) methodInvocationExpression.resolve();
+
+                    PsiReferenceExpression reference = null;
+                    PsiElement resolved = null;
+                    if (methodInvocationExpression instanceof PsiReferenceExpression) {
+                        reference = (PsiReferenceExpression) methodInvocationExpression;
+                        resolved = reference.resolve();
+                    }
+
+                    if (resolved instanceof PsiMethod) {
+                        PsiMethod previousChainedMethodInvocation = (PsiMethod) resolved;
                         List<PsiMethod> parentClassMethods = new ArrayList<>();
                         if (parentClass != null) {
                             parentClassMethods.addAll(Arrays.asList(parentClass.getMethods()));
@@ -248,23 +256,34 @@ public class MethodObject implements AbstractMethodDeclaration {
                                 }
                             }
                         }
-                    } else if (!PsiTreeUtil.findChildrenOfType(methodInvocationExpression, PsiReferenceExpression.class).isEmpty()) {
-                        Collection<PsiReferenceExpression> references = PsiTreeUtil.findChildrenOfType(methodInvocationExpression, PsiReferenceExpression.class);
-                        for (PsiReferenceExpression reference : references) {
-                            PsiElement resolvedReference = reference.resolve();
-                            if (resolvedReference instanceof PsiField) {
-                                PsiField psiField = (PsiField) reference.resolve();
-                                if (psiField != null && psiField.getContainingClass() != null && psiField.getContainingClass().equals(parentClass)
-                                        || psiField != null && parentClass != null && psiField.getContainingClass() != null && parentClass.isInheritor(psiField.getContainingClass(), true)) {
-                                    for (MethodInvocationObject methodInvocationObject : methodInvocations) {
-                                        if (methodInvocationExpression.equals(methodInvocation.getMethodExpression())) {
-                                            return methodInvocationObject;
-                                        }
+                    } else if (resolved instanceof PsiField) {
+                        PsiField variableBinding = (PsiField) resolved;
+
+                        if (variableBinding.getContainingClass().equals(parentClass) ||
+                                parentClass.isInheritor(variableBinding.getContainingClass(), true)) {
+                            for (MethodInvocationObject methodInvocationObject : methodInvocations) {
+                                if (methodInvocationObject.getMethodInvocation().equals(methodInvocation)) {
+                                    return methodInvocationObject;
+                                }
+                            }
+                        }
+                    } else if (resolved != null) {
+                        if (resolved instanceof PsiVariable) {
+                            if (resolved instanceof PsiParameter) {
+                                for (MethodInvocationObject methodInvocationObject : methodInvocations) {
+                                    if (methodInvocationObject.getMethodInvocation().equals(methodInvocation)) {
+                                        return methodInvocationObject;
                                     }
                                 }
                             }
                         }
                     } else if (methodInvocationExpression instanceof PsiThisExpression) {
+                        for (MethodInvocationObject methodInvocationObject : methodInvocations) {
+                            if (methodInvocationObject.getMethodInvocation().equals(methodInvocation)) {
+                                return methodInvocationObject;
+                            }
+                        }
+                    } else if (methodInvocationExpression == null) {
                         for (MethodInvocationObject methodInvocationObject : methodInvocations) {
                             if (methodInvocationObject.getMethodInvocation().equals(methodInvocation)) {
                                 return methodInvocationObject;

--- a/src/main/java/org/jetbrains/research/intellijdeodorant/core/ast/MethodObject.java
+++ b/src/main/java/org/jetbrains/research/intellijdeodorant/core/ast/MethodObject.java
@@ -221,18 +221,17 @@ public class MethodObject implements AbstractMethodDeclaration {
                     }
                 }
                 if (methodInvocation != null) {
-                    PsiExpression methodInvocationExpression = methodInvocation.getMethodExpression().getQualifierExpression();
+                    PsiExpression methodQualifierExpression = methodInvocation.getMethodExpression().getQualifierExpression();
                     List<MethodInvocationObject> methodInvocations = statementObject.getMethodInvocations();
 
-                    PsiReferenceExpression reference = null;
-                    PsiElement resolved = null;
-                    if (methodInvocationExpression instanceof PsiReferenceExpression) {
-                        reference = (PsiReferenceExpression) methodInvocationExpression;
-                        resolved = reference.resolve();
+                    PsiElement resolvedElement = null;
+                    if (methodQualifierExpression instanceof PsiReferenceExpression) {
+                        PsiReferenceExpression reference = (PsiReferenceExpression) methodQualifierExpression;
+                        resolvedElement = reference.resolve();
                     }
 
-                    if (resolved instanceof PsiMethod) {
-                        PsiMethod previousChainedMethodInvocation = (PsiMethod) resolved;
+                    if (resolvedElement instanceof PsiMethod) {
+                        PsiMethod previousChainedMethodInvocation = (PsiMethod) resolvedElement;
                         List<PsiMethod> parentClassMethods = new ArrayList<>();
                         if (parentClass != null) {
                             parentClassMethods.addAll(Arrays.asList(parentClass.getMethods()));
@@ -251,41 +250,41 @@ public class MethodObject implements AbstractMethodDeclaration {
                         }
                         if (!isDelegationChain && foundInParentClass) {
                             for (MethodInvocationObject methodInvocationObject : methodInvocations) {
-                                if (methodInvocationExpression.equals(methodInvocation.getMethodExpression())) {
+                                if (methodQualifierExpression.equals(methodInvocation.getMethodExpression())) {
                                     return methodInvocationObject;
                                 }
                             }
                         }
-                    } else if (resolved instanceof PsiField) {
-                        PsiField variableBinding = (PsiField) resolved;
+                    } else if (resolvedElement instanceof PsiField) {
+                        PsiField resolvedField = (PsiField) resolvedElement;
 
-                        if (variableBinding.getContainingClass().equals(parentClass) ||
-                                parentClass.isInheritor(variableBinding.getContainingClass(), true)) {
-                            for (MethodInvocationObject methodInvocationObject : methodInvocations) {
-                                if (methodInvocationObject.getMethodInvocation().equals(methodInvocation)) {
-                                    return methodInvocationObject;
-                                }
-                            }
-                        }
-                    } else if (resolved != null) {
-                        if (resolved instanceof PsiVariable) {
-                            if (resolved instanceof PsiParameter) {
+                        if (parentClass != null && resolvedField.getContainingClass() != null) {
+                            if (parentClass.equals(resolvedField.getContainingClass()) ||
+                                    parentClass.isInheritor(resolvedField.getContainingClass(), true)) {
                                 for (MethodInvocationObject methodInvocationObject : methodInvocations) {
-                                    if (methodInvocationObject.getMethodInvocation().equals(methodInvocation)) {
+                                    if (methodInvocation.equals(methodInvocationObject.getMethodInvocation())) {
                                         return methodInvocationObject;
                                     }
                                 }
                             }
                         }
-                    } else if (methodInvocationExpression instanceof PsiThisExpression) {
+                    } else if (resolvedElement != null) {
+                        if (resolvedElement instanceof PsiParameter) {
+                            for (MethodInvocationObject methodInvocationObject : methodInvocations) {
+                                if (methodInvocation.equals(methodInvocationObject.getMethodInvocation())) {
+                                    return methodInvocationObject;
+                                }
+                            }
+                        }
+                    } else if (methodQualifierExpression instanceof PsiThisExpression) {
                         for (MethodInvocationObject methodInvocationObject : methodInvocations) {
-                            if (methodInvocationObject.getMethodInvocation().equals(methodInvocation)) {
+                            if (methodInvocation.equals(methodInvocationObject.getMethodInvocation())) {
                                 return methodInvocationObject;
                             }
                         }
-                    } else if (methodInvocationExpression == null) {
+                    } else if (methodQualifierExpression == null) {
                         for (MethodInvocationObject methodInvocationObject : methodInvocations) {
-                            if (methodInvocationObject.getMethodInvocation().equals(methodInvocation)) {
+                            if (methodInvocation.equals(methodInvocationObject.getMethodInvocation())) {
                                 return methodInvocationObject;
                             }
                         }


### PR DESCRIPTION
Pull request contains fixes for 3 bugs, most of them Extract Class specific:
1) `MethodObject::isDelegate` rewritten, now it matches `MethodDeclarationUtility::isDelegate()`
2) `AbstractMethodFragment::processMethodInvocation` now adds method's argument types to the MethodInvocationObject. They are important, because, for instance, otherwise `getField(a)` may be confused with `getField()` and be considered as a getter AKA field accessor.
3) Fixed adding elements to `nonDistinctInvokedMethodThroughThisReference()`. Not sure what is wrong here, I just wrote the same thing original plugin's author meant and it worked.