### PR TITLE
 Fix Issue #51: collectorAdders and Issue #53 local variables methods invocation

### DIFF
--- a/src/main/java/org/jetbrains/research/intellijdeodorant/core/ast/decomposition/AbstractMethodFragment.java
+++ b/src/main/java/org/jetbrains/research/intellijdeodorant/core/ast/decomposition/AbstractMethodFragment.java
@@ -273,8 +273,7 @@ public abstract class AbstractMethodFragment {
                 }
 
                 if (resolveMethod == null || methodInvocation.getMethodExpression().getQualifierExpression() != null) {
-                    PsiMethodCallExpression methodExpression = getFirstMethodCallInAChain(methodInvocation);
-                    PsiReferenceExpression qualifierExpression = getFirstQualifierInAChain(methodExpression);
+                    PsiReferenceExpression qualifierExpression = getFirstQualifierInAChain(methodInvocation);
 
                     if (qualifierExpression == null) {
                         PsiMethod resolvedMethod = resolveMethod(methodInvocation);
@@ -303,7 +302,7 @@ public abstract class AbstractMethodFragment {
                         }
 
                         if (originClassName != null && !originClassName.equals("")) {
-                            processMethodInvocation(methodExpression, originClassName, false);
+                            processMethodInvocation(methodInvocation, originClassName, false);
                         }
                     }
                 } else {

--- a/src/main/java/org/jetbrains/research/intellijdeodorant/core/ast/decomposition/AbstractMethodFragment.java
+++ b/src/main/java/org/jetbrains/research/intellijdeodorant/core/ast/decomposition/AbstractMethodFragment.java
@@ -11,8 +11,6 @@ import org.jetbrains.research.intellijdeodorant.core.ast.util.MethodDeclarationU
 
 import java.util.*;
 
-import static java.util.stream.Collectors.toList;
-import static org.jetbrains.research.intellijdeodorant.core.ast.ASTReader.getExaminedProject;
 import static org.jetbrains.research.intellijdeodorant.utils.PsiUtils.resolveMethod;
 
 public abstract class AbstractMethodFragment {
@@ -276,7 +274,6 @@ public abstract class AbstractMethodFragment {
 
                 if (resolveMethod == null || methodInvocation.getMethodExpression().getQualifierExpression() != null) {
                     PsiMethodCallExpression methodExpression = getFirstMethodCallInAChain(methodInvocation);
-                    String methodName = methodExpression.getMethodExpression().getReferenceName();
                     PsiReferenceExpression qualifierExpression = getFirstQualifierInAChain(methodExpression);
 
                     if (qualifierExpression == null) {
@@ -365,7 +362,7 @@ public abstract class AbstractMethodFragment {
         addMethodInvocation(methodInvocationObject);
 
         AbstractVariable invoker = MethodDeclarationUtility
-                .processMethodInvocationExpression(getFirstQualifierInAChain(methodInvocation));
+                .processMethodInvocationExpression(methodInvocation.getMethodExpression().getQualifierExpression());
 
         if (invoker != null) {
             PlainVariable initialVariable = invoker.getInitialVariable();

--- a/src/main/java/org/jetbrains/research/intellijdeodorant/core/ast/decomposition/AbstractMethodFragment.java
+++ b/src/main/java/org/jetbrains/research/intellijdeodorant/core/ast/decomposition/AbstractMethodFragment.java
@@ -291,10 +291,10 @@ public abstract class AbstractMethodFragment {
                         if (resolvedElement instanceof PsiParameter
                                 && resolvedElement.getParent() instanceof PsiParameterList) {
                             PsiType resolvedQualifierType = ((PsiParameter) resolvedElement).getType();
-                            originClassName = findClassBySimpleNameAndGetQualifiedName(resolvedQualifierType, methodName);
+                            originClassName = getQualifiedNameByType(resolvedQualifierType);
                         } else if (resolvedElement instanceof PsiField) {
                             PsiType resolvedQualifierType = ((PsiField) resolvedElement).getType();
-                            originClassName = findClassBySimpleNameAndGetQualifiedName(resolvedQualifierType, methodName);
+                            originClassName = getQualifiedNameByType(resolvedQualifierType);
                         }
                         if (originClassName != null && !originClassName.equals("")) {
                             processMethodInvocation(methodExpression, originClassName, false);
@@ -327,19 +327,15 @@ public abstract class AbstractMethodFragment {
         return null;
     }
 
-    private String findClassBySimpleNameAndGetQualifiedName(PsiType classReferenceType, String methodName) {
-        String classQualifiedName = "";
+    private String getQualifiedNameByType(PsiType classReferenceType) {
         if (classReferenceType instanceof PsiClassReferenceType) {
-            String classSimpleName = ((PsiClassReferenceType) classReferenceType).getName();
-            List<PsiClass> candidateClasses = getExaminedProject().getClasses().stream()
-                    .filter(psiClass -> classSimpleName.equals(psiClass.getName())).collect(toList());
-            for (PsiClass psiClass : candidateClasses) {
-                if (psiClass.findMethodsByName(methodName, true).length != 0) {
-                    classQualifiedName = psiClass.getQualifiedName();
-                }
+            PsiClass resolvedClass = ((PsiClassReferenceType) classReferenceType).resolve();
+            if (resolvedClass != null) {
+                return resolvedClass.getQualifiedName();
             }
         }
-        return classQualifiedName;
+
+        return "";
     }
 
     private void processMethodInvocation(PsiMethodCallExpression methodInvocation, String originClassName, boolean isMethodStatic) {


### PR DESCRIPTION
The plugin does not process methods invocations for the methods that are not in the Project class entity. That is the reason for the `isCollectorAdder()` to work wrong: is simply does not see a method invocation inside it and always returns false.