### PR TITLE
Removed wrong inner class extraction

### DIFF
--- a/src/main/java/org/jetbrains/research/intellijdeodorant/utils/PsiUtils.java
+++ b/src/main/java/org/jetbrains/research/intellijdeodorant/utils/PsiUtils.java
@@ -93,7 +93,7 @@ public class PsiUtils {
         PsiClass[] psiClasses = psiFile.getClasses();
         for (PsiClass psiClass : psiClasses) {
             allClasses.add(psiClass);
-            allClasses.addAll(Arrays.asList(psiClass.getAllInnerClasses()));
+            allClasses.addAll(Arrays.asList(psiClass.getInnerClasses()));
         }
         return allClasses;
     }


### PR DESCRIPTION
`getAllInnerClasses` means to extract inner classes from the superclass. This is wrong behavior - inner classes of superclasses are either not from the project class entity (and we should not try to get refactoring opportunities from it) or we will get them when extracting the superclass. 