### PR TITLE
Remove feature.usage.event.log.collect.and.upload

### DIFF
--- a/src/main/java/org/jetbrains/research/intellijdeodorant/ide/fus/IntelliJDeodorantLoggerProvider.java
+++ b/src/main/java/org/jetbrains/research/intellijdeodorant/ide/fus/IntelliJDeodorantLoggerProvider.java
@@ -14,9 +14,7 @@ public class IntelliJDeodorantLoggerProvider extends StatisticsEventLoggerProvid
 
     @Override
     public boolean isRecordEnabled() {
-        return !ApplicationManager.getApplication().isUnitTestMode() &&
-                Registry.is("feature.usage.event.log.collect.and.upload") &&
-                StatisticsUploadAssistant.isCollectAllowed();
+        return false;
     }
 
     @Override


### PR DESCRIPTION
This registry setting was removed by Dmitry Jemerov <yole@jetbrains.com> on 3 May 2021 (GIT: http://git.jetbrains.org/?p=idea/community.git;a=commitdiff;h=f1a7080d21f4c757f31acb7c0c0d2b90664ec0af), and this plugin is happily throwing multiple stack errors.  Removed to eliminate this fatal error.